### PR TITLE
Fix GitHub release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Make the production plugin bundle
+        run: |
+          release_version=$(cat package.json | jq -r '.version')
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+          yarn
+          yarn build
+      - name: Perform Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.RELEASE_VERSION }}
+          tag_name: v${{ env.RELEASE_VERSION }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Budibase-Signature-Plugin",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "A plugin that allows signatures to be created and saved in budibase",
   "license": "MIT",
   "svelte": "index.js",


### PR DESCRIPTION
hey @FlaminWrap, thanks so much for your component contribution. The signature component will be useful for so many people! 

I've included the latest release.yml in this PR to allow GitHub to make a new plugin build for each release. This is what allows Budibase to grab the plugin when importing it with the repository URL. This morning we had a user having an issue with importing your component [here](https://github.com/Budibase/budibase/discussions/9742#discussioncomment-5051634). This update should hopefully fix this when users try to import the plugin in future.

Thanks again for your work!